### PR TITLE
less specific ruby version to speed up Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 
 language: ruby
 rvm:
-    - 2.4.0
+    - 2.4
 
 cache:
   bundler: true


### PR DESCRIPTION
So we use Travis' preinstalled Ruby version instead of downloading/compiling/installing it for every build.