### PR TITLE
Custom parser for caretakers email in FAQ data

### DIFF
--- a/_src/_data/faq.yml
+++ b/_src/_data/faq.yml
@@ -60,7 +60,7 @@
 
 - question: Can my organization be a Caretaker?
   answer: |
-    Maybe! If you think you’re a good fit, contact us at {{ site.data.contact.email_caretakers }}.
+    Maybe! If you think you’re a good fit, contact us at !EMAIL_CARETAKERS!.
 
 ## Transactions
 - question: Can I delete a Transaction?

--- a/_src/faq.html
+++ b/_src/faq.html
@@ -7,6 +7,8 @@ subtitle: Get answers to your most pressing questions
 css: page-faq
 ---
 
+{% capture email_caretakers %}<a href="mailto:{{ site.data.contact.email_caretakers }}">{{ site.data.contact.email_caretakers }}</a>{% endcapture %}
+
 <section class="section section--faq">
     <div class="row row--narrow">
 
@@ -21,7 +23,7 @@ css: page-faq
                 {% assign id = faq.question | downcase | replace: ' ','-' | replace: '?', '' %}
 
                 <h1 class="faq__question" id="{{ id }}"><a class="header-link" href="#{{ id }}">#</a> {{ faq.question }}</h1>
-                <div class="faq__answer">{{ faq.answer | markdownify }}</div>
+                <div class="faq__answer">{{ faq.answer | replace: '!EMAIL_CARETAKERS!', email_caretakers | markdownify }}</div>
             {% endfor %}
         </div>
 


### PR DESCRIPTION
Long story short, Liquid variables can't be accessed from within Jekyll's data files.

This PR works around that by simply using a `replace` filter for the string `!EMAIL_CARETAKERS!` for all answers in the FAQ. 

So this:

```yaml
- question: Can my organization be a Caretaker?
  answer: |
    Maybe! If you think you’re a good fit, contact us at !EMAIL_CARETAKERS!.
```

results in:

<img width="678" alt="screen shot 2017-11-07 at 12 54 27" src="https://user-images.githubusercontent.com/90316/32492517-d6143bf4-c3ba-11e7-8336-4fe6ee7709b8.png">

Closes #24 