### PR TITLE
Name & Imprint changes

### DIFF
--- a/_src/_data/contact.yml
+++ b/_src/_data/contact.yml
@@ -1,4 +1,5 @@
-company: "Interplanetary Origins e.V."
+company: "Interplanetary Database Foundation e.V."
+registration: "Registration VR 36146 B"
 address:
     street: "Wichertstraße 14a"
     zip: "10439"

--- a/_src/_includes/contact.html
+++ b/_src/_includes/contact.html
@@ -6,9 +6,9 @@
         <p>{{ contact.registration}}</p>
         <h5>Represented by</h5>
         <p>
-            {{ site.data.board[0].position }}: {{ site.data.board[0].name }}<br />
-            {{ site.data.board[1].position }}: {{ site.data.board[1].name }}<br />
-            {{ site.data.board[2].position }}: {{ site.data.board[2].name }}
+            {% for representative in site.data.board | limit: 3 %}
+                {{ representative.position }}: {{ representative.name }}<br />
+            {% endfor %}
         </p>
     {% endif %}
     <p>

--- a/_src/_includes/contact.html
+++ b/_src/_includes/contact.html
@@ -2,6 +2,15 @@
 
 <div class="company">
     <h4 class="company__name">{{ contact.company }}</h4>
+    {% if include.imprint %}
+        <p>{{ contact.registration}}</p>
+        <h5>Represented by</h5>
+        <p>
+            {{ site.data.board[0].position }}: {{ site.data.board[0].name }}<br />
+            {{ site.data.board[1].position }}: {{ site.data.board[1].name }}<br />
+            {{ site.data.board[2].position }}: {{ site.data.board[2].name }}
+        </p>
+    {% endif %}
     <p>
         <a href="mailto:{{ contact.email }}">{{ contact.email }}</a>
     </p>

--- a/_src/imprint.md
+++ b/_src/imprint.md
@@ -6,4 +6,4 @@ title: Imprint
 narrow: true
 ---
 
-{% include contact.html %}
+{% include contact.html imprint="true" %}


### PR DESCRIPTION
PR adds more data to the contact block on the imprint page. The register number is newly added to `_data/contact.yml` file while the representatives and their data are pulled from the existing `_data/board.yml` file, automatically grabbing the first 3 people from that file.

All resulting in:

<img width="496" alt="screen shot 2017-11-07 at 13 13 40" src="https://user-images.githubusercontent.com/90316/32493263-81756480-c3bd-11e7-86eb-3586e12394b5.png">